### PR TITLE
[nrf toup]: sanitycheck: test if .name or .arch is in coverage_platform

### DIFF
--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -2313,8 +2313,8 @@ class ProjectBuilder(FilterBuilder):
 
         overlays = extract_overlays(args)
 
-        if (self.testcase.extra_configs or self.coverage or
-                self.asan or self.ubsan):
+        if os.path.exists(os.path.join(instance.build_dir,
+                                       "sanitycheck", "testcase_extra.conf")):
             overlays.append(os.path.join(instance.build_dir,
                                          "sanitycheck", "testcase_extra.conf"))
 


### PR DESCRIPTION
 [nrf toup]: sanitycheck: check existence of testcase_extra.conf

Running sanitycheck for multiple platforms but only request coverage
on a single platform fails, example:
```
  sanitycheck --enable-coverage --coverage-platform nrf52840dk_nrf52840
  -p nrf52840dk_nrf52840 -p nrf52dk_nrf52832 -T <sample>
```

This happens because `testcase_extra.conf` will only be created if the
current platform is included in the list of coverage platforms.

The error in the example above that would be seen is:
```
  File not found:
      <...>/sanitycheck/testcase_extra.conf
```
This commit now uses the existence of `testcase_extra.conf` which is
created in the method `create_overlay()` before appending
the conf file to the list of overlay files.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>