### PR TITLE
[nrf noup] net: lib: mqtt: Transition to zsock_setsockopt

### DIFF
--- a/subsys/net/lib/mqtt/mqtt_transport_socket_tls.c
+++ b/subsys/net/lib/mqtt/mqtt_transport_socket_tls.c
@@ -79,10 +79,10 @@ int mqtt_client_tls_connect(struct mqtt_client *client)
 	}
 
 	if (tls_config->session_cache == TLS_SESSION_CACHE_ENABLED) {
-		ret = setsockopt(client->transport.tls.sock, SOL_TLS,
-				 TLS_SESSION_CACHE,
-				 &tls_config->session_cache,
-				 sizeof(tls_config->session_cache));
+		ret = zsock_setsockopt(client->transport.tls.sock, SOL_TLS,
+				       TLS_SESSION_CACHE,
+				       &tls_config->session_cache,
+				       sizeof(tls_config->session_cache));
 		if (ret < 0) {
 			goto error;
 		}


### PR DESCRIPTION
The Zephyr's MQTT implementation was switched to use zsock_* API instead
of POSIX APIs (which is always avaialble in Zephyr, regardless of POSIX
configuration). We should apply the same to the downstream changes.

This commit could be squashed into
19c66e05d970234e84f8d8571e0e33a8a5ba7fe4 on next rebase or upmerge.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>